### PR TITLE
✨ NEW: Add `solution` directive

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,3 @@ sphinx>=3.0
 sphinx-book-theme
 myst-nb
 sphinxcontrib-bibtex
-sphinxcontrib.prettyproof

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ master_doc = "index"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.
-extensions = ["sphinxcontrib.prettyproof", "myst_parser", "sphinxcontrib.bibtex"]
+extensions = ["sphinxcontrib.prettyproof", "myst_nb", "sphinxcontrib.bibtex"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/syntax.md
+++ b/docs/source/syntax.md
@@ -3,8 +3,6 @@
 ```{note}
 This documentation utilized the [Markedly Structured Text (MyST)](https://myst-parser.readthedocs.io/en/latest/index.html) syntax.
 ```
-```{proof:solution} my-exercise
-```
 
 ## Proofs
 

--- a/docs/source/syntax.md
+++ b/docs/source/syntax.md
@@ -3,6 +3,8 @@
 ```{note}
 This documentation utilized the [Markedly Structured Text (MyST)](https://myst-parser.readthedocs.io/en/latest/index.html) syntax.
 ```
+```{proof:solution} my-exercise
+```
 
 ## Proofs
 

--- a/docs/source/syntax.md
+++ b/docs/source/syntax.md
@@ -64,18 +64,18 @@ A theorem directive can be included using the `proof:theorem` pattern. The direc
 
 * `label` : text
 
-	A unique identifier for your theorem that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your theorem that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the theorem’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the theorem’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off theorem auto numbering.
+    Turns off theorem auto numbering.
 
-	```{math}
-	\DeclareMathOperator*{\argmax}{arg\,max}
-	\DeclareMathOperator*{\argmin}{arg\,min}
-	```
+    ```{math}
+    \DeclareMathOperator*{\argmax}{arg\,max}
+    \DeclareMathOperator*{\argmin}{arg\,min}
+    ```
 
 **Example**
 
@@ -135,13 +135,13 @@ An axiom directive can be included using the `proof:theorem` pattern. The direct
 
 * `label` : text
 
-	A unique identifier for your axiom that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your axiom that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the axiom’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the axiom’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off axiom auto numbering.
+    Turns off axiom auto numbering.
 
 **Example**
 
@@ -174,13 +174,13 @@ A lemma directive can be included using the `proof:lemma` pattern. The directive
 
 * `label` : text
 
-	A unique identifier for your lemma that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your lemma that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the lemma’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the lemma’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off lemma auto numbering.
+    Turns off lemma auto numbering.
 
 **Example**
 
@@ -225,13 +225,13 @@ A definition directive can be included using the `proof:definition` pattern. The
 
 * `label` : text
 
-	A unique identifier for your definition that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your definition that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the definition’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the definition’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off definition auto numbering.
+    Turns off definition auto numbering.
 
 **Example**
 
@@ -278,13 +278,13 @@ A criterion directive can be included using the `proof:criterion` pattern. The d
 
 * `label` : text
 
-	A unique identifier for your criterion that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your criterion that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the criterion’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the criterion’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off criterion auto numbering.
+    Turns off criterion auto numbering.
 
 **Example**
 
@@ -327,13 +327,13 @@ A remark directive can be included using the `proof:remark` pattern. The directi
 
 * `label` : text
 
-	A unique identifier for your remark that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your remark that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the remark’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the remark’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off remark auto numbering.
+    Turns off remark auto numbering.
 
 **Example**
 
@@ -411,13 +411,13 @@ A corollary directive can be included using the `proof:corollary` pattern. The d
 
 * `label` : text
 
-	A unique identifier for your corollary that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your corollary that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the corollary’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the corollary’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off corollary auto numbering.
+    Turns off corollary auto numbering.
 
 **Example**
 
@@ -453,13 +453,13 @@ An algorithm directive can be included using the `proof:algorithm` pattern. The 
 
 * `label` : text
 
-	A unique identifier for your algorithm that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your algorithm that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the algorithm’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the algorithm’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off algorithm auto numbering.
+    Turns off algorithm auto numbering.
 
 **Example**
 
@@ -473,11 +473,11 @@ An algorithm directive can be included using the `proof:algorithm` pattern. The 
 1. $f(u, v) \leftarrow 0$ for all edges $(u,v)$
 2. While there is a path $p$ from $s$ to $t$ in $G_{f}$ such that $c_{f}(u,v)>0$ for all edges $(u,v) \in p$:
 
-	1. Find $c_{f}(p)= \min \{c_{f}(u,v):(u,v)\in p\}$
-	2. For each edge $(u,v) \in p$
+    1. Find $c_{f}(p)= \min \{c_{f}(u,v):(u,v)\in p\}$
+    2. For each edge $(u,v) \in p$
 
-		1. $f(u,v) \leftarrow f(u,v) + c_{f}(p)$ *(Send flow along the path)*
-		2. $f(u,v) \leftarrow f(u,v) - c_{f}(p)$ *(The flow might be "returned" later)*
+        1. $f(u,v) \leftarrow f(u,v) + c_{f}(p)$ *(Send flow along the path)*
+        2. $f(u,v) \leftarrow f(u,v) - c_{f}(p)$ *(The flow might be "returned" later)*
 ```
 
 **MyST Syntax**
@@ -492,13 +492,13 @@ An algorithm directive can be included using the `proof:algorithm` pattern. The 
 
 1. $f(u, v) \leftarrow 0$ for all edges $(u,v)$
 2. While there is a path $p$ from $s$ to $t$ in $G_{f}$ such that $c_{f}(u,v)>0$
-	for all edges $(u,v) \in p$:
+    for all edges $(u,v) \in p$:
 
-	1. Find $c_{f}(p)= \min \{c_{f}(u,v):(u,v)\in p\}$
-	2. For each edge $(u,v) \in p$
+    1. Find $c_{f}(p)= \min \{c_{f}(u,v):(u,v)\in p\}$
+    2. For each edge $(u,v) \in p$
 
-		1. $f(u,v) \leftarrow f(u,v) + c_{f}(p)$ *(Send flow along the path)*
-		2. $f(u,v) \leftarrow f(u,v) - c_{f}(p)$ *(The flow might be "returned" later)*
+        1. $f(u,v) \leftarrow f(u,v) + c_{f}(p)$ *(Send flow along the path)*
+        2. $f(u,v) \leftarrow f(u,v) - c_{f}(p)$ *(The flow might be "returned" later)*
 ```
 ``````
 
@@ -514,13 +514,13 @@ An exercise directive can be included using the `proof:exercise` pattern. The di
 
 * `label` : text
 
-	A unique identifier for your exercise that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your exercise that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the exercise’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the exercise’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off exercise auto numbering.
+    Turns off exercise auto numbering.
 
 **Example**
 
@@ -561,19 +561,136 @@ _Source:_ [QuantEcon](https://python-programming.quantecon.org/functions.html#Ex
 You can refer to an exercise using the `{proof:ref}` role like: ```{proof:ref}`my-exercise` ```, which will replace the reference with the exercise number like so: {proof:ref}`my-exercise`. When an explicit text is provided, this caption will serve as the title of the reference.
 
 
+## Solutions
+
+A solution directive can be included using the `proof:solution` pattern. It takes in the label of the directive it wants to link to as a required argument. Unlike other directives, which support enumerability and unenumerability (with the exception of the `proof` directive), the solution directive is unenumerable. The following options are also supported:
+
+* `label` : text
+
+    A unique identifier for your solution that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+* `class` : text
+
+    Value of the solution’s class attribute which can be used to add custom CSS or JavaScript.
+
+```{note}
+The title of the solution directive links directly to the referred directive. Furthermore, while the examples below link a solution to an exercise directive, any directive which specifies a `label` option can be referred. It is the discretion of the user to utilize the solution directive as they see fit.
+```
+
+**Example**
+
+````{proof:solution} my-exercise
+:label: my-solution
+
+Here's one solution.
+
+```{code-block} python
+def factorial(n):
+    k = 1
+    for i in range(n):
+        k = k * (i + 1)
+    return k
+
+factorial(4)
+```
+````
+
+**MyST Syntax**
+
+``````md
+````{proof:solution} my-exercise
+:label: my-solution
+
+Here's one solution.
+
+```{code-block} python
+def factorial(n):
+    k = 1
+    for i in range(n):
+        k = k * (i + 1)
+    return k
+
+factorial(4)
+```
+````
+``````
+
+_Source:_ [QuantEcon](https://python-programming.quantecon.org/functions.html#Exercise-1)
+
+### Referencing Solutions
+
+You can refer to a solution using the `{proof:ref}` role like: ```{proof:ref}`my-solution` ``` the output of which depends on the attributes of the linked directive. If the linked directive is enumerable, the role will replace the solution reference with the linked directive type and its appropriate number like so: {proof:ref}`my-solution`.
+
+In the event that the directive being referenced is unenumerable, the reference will display its title, for example, {proof:ref}`nfactorial-solution`. Click the toggle on the right to find the supporting directives.
+
+````{toggle}
+```{proof:exercise} $n!$ Factorial
+:label: nfactorial
+:nonumber:
+
+Write a function `factorial` such that `factorial(int n)` returns $n!$
+for any positive integer $n$.
+```
+
+```{proof:solution} nfactorial
+:label: nfactorial-solution
+
+Here's a solution in Java.
+
+```{code-block} java
+static int factorial(int n){
+    if (n == 0)
+        return 1;
+    else {
+        return(n * factorial(n-1));
+    }
+}
+```
+````
+
+If the referenced directive is nameless, then the reference will default to the type of the directive being referenced like so: {proof:ref}`nfactorial2-solution`. The toggle on the right includes the supporting directives for this example.
+
+
+````{toggle}
+```{proof:exercise}
+:label: nfactorial2
+:nonumber:
+
+Write a function `factorial` such that `factorial(int n)` returns $n!$
+for any positive integer $n$.
+```
+
+```{proof:solution} nfactorial2
+:label: nfactorial2-solution
+
+Here's a solution in Java.
+
+```{code-block} java
+static int factorial(int n){
+    if (n == 0)
+        return 1;
+    else {
+        return(n * factorial(n-1));
+    }
+}
+```
+````
+
+Lastly, when an explicit text is provided, this caption will serve as the title of the reference.
+
+
 ## Examples
 
 An example directive can be included using the `proof:example` pattern. The directive is enumerated by default and can take in an optional title argument. The following options are also supported:
 
 * `label` : text
 
-	A unique identifier for your example that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your example that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the example’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the example’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off example auto numbering.
+    Turns off example auto numbering.
 
 **Example**
 
@@ -636,13 +753,13 @@ A property directive can be included using the `proof:property` pattern. The dir
 
 * `label` : text
 
-	A unique identifier for your property that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your property that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the property’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the property’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off property auto numbering.
+    Turns off property auto numbering.
 
 **Example**
 
@@ -672,13 +789,13 @@ An observation directive can be included using the `proof:observation` pattern. 
 
 * `label` : text
 
-	A unique identifier for your observation that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your observation that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the observation’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the observation’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off observation auto numbering.
+    Turns off observation auto numbering.
 
 **Example**
 
@@ -708,13 +825,13 @@ A proposition directive can be included using the `proof:proposition` pattern. T
 
 * `label` : text
 
-	A unique identifier for your proposition that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
+    A unique identifier for your proposition that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
 * `class` : text
 
-	Value of the proposition’s class attribute which can be used to add custom CSS or JavaScript.
+    Value of the proposition’s class attribute which can be used to add custom CSS or JavaScript.
 * `nonumber` : flag (empty)
 
-	Turns off proposition auto numbering.
+    Turns off proposition auto numbering.
 
 **Example**
 

--- a/docs/source/testing.md
+++ b/docs/source/testing.md
@@ -1,5 +1,10 @@
 # Testing
 
+```{proof:solution} my-exercise2
+blabla bla bla.
+bla bla bla bla.
+```
+
 For code tests, sphinxcontrib-prettyproof uses `pytest`.
 
 Run the tests with the following command:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras = {
         "sphinx>=3.0",
         "sphinx-book-theme",
         "sphinxcontrib-bibtex",
-        "myst-parser",
+        "myst-nb",
     ],
 }
 

--- a/sphinxcontrib/_static/proof.css
+++ b/sphinxcontrib/_static/proof.css
@@ -218,3 +218,21 @@ div.proposition {
 div.proposition p.admonition-title {
 	background-color: var(--note-title-color);
 }
+
+/*********************************************
+* Solution *
+*********************************************/
+div.solution{
+	padding: .6rem .8rem !important;
+	border-left: .2rem solid var(--grey-border-color);
+	background-color: none;
+}
+
+div.solution p.admonition-title {
+	background-color: transparent;
+	text-decoration: none;
+}
+
+div.solution p.admonition-title a{
+	color: #333 !important;
+}

--- a/sphinxcontrib/prettyproof/__init__.py
+++ b/sphinxcontrib/prettyproof/__init__.py
@@ -12,9 +12,7 @@ from typing import Any, Dict, Set, Union
 from sphinx.config import Config
 from sphinx.application import Sphinx
 from sphinx.environment import BuildEnvironment
-from .nodes import enumerable_node, visit_enumerable_node, depart_enumerable_node
-from .nodes import unenumerable_node, visit_unenumerable_node, depart_unenumerable_node
-from .nodes import proof_node, visit_proof_node, depart_proof_node
+from .nodes import nodes_collection
 from .domain import ProofDomain
 from sphinx.util import logging
 from sphinx.util.fileutil import copy_asset
@@ -77,21 +75,26 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_domain(ProofDomain)
     app.add_node(
-        proof_node,
-        singlehtml=(visit_proof_node, depart_proof_node),
-        html=(visit_proof_node, depart_proof_node),
+        nodes_collection["default"][0],
+        singlehtml=nodes_collection["default"][1],
+        html=nodes_collection["default"][1],
     )
     app.add_node(
-        unenumerable_node,
-        singlehtml=(visit_unenumerable_node, depart_unenumerable_node),
-        html=(visit_unenumerable_node, depart_unenumerable_node),
+        nodes_collection["linked"][0],
+        singlehtml=nodes_collection["linked"][1],
+        html=nodes_collection["linked"][1],
+    )
+    app.add_node(
+        nodes_collection["unenumerable"][0],
+        singlehtml=nodes_collection["unenumerable"][1],
+        html=nodes_collection["unenumerable"][1],
     )
     app.add_enumerable_node(
-        enumerable_node,
+        nodes_collection["enumerable"][0],
         "proof",
         None,
-        singlehtml=(visit_enumerable_node, depart_enumerable_node),
-        html=(visit_enumerable_node, depart_enumerable_node),
+        singlehtml=nodes_collection["enumerable"][1],
+        html=nodes_collection["enumerable"][1],
     )
 
     return {

--- a/sphinxcontrib/prettyproof/directive.py
+++ b/sphinxcontrib/prettyproof/directive.py
@@ -41,6 +41,10 @@ class ElementDirective(SphinxDirective):
         if not hasattr(env, "proof_list"):
             env.proof_list = {}
 
+        # If solution directive, always unenumerable
+        if typ == "solution":
+            self.options["nonumber"] = True
+
         # If class in options add to class array
         classes, class_name = [domain_name, typ], self.options.get("class", [])
         if class_name:
@@ -53,22 +57,28 @@ class ElementDirective(SphinxDirective):
             node_id = f"{label}"
         else:
             self.options["noindex"] = True
-            label = f"{typ}-{serial_no}"
-            node_id = f"{typ}-{serial_no}"
+            label = f"{self.env.docname}-{typ}-{serial_no}"
+            node_id = f"{self.env.docname}-{typ}-{serial_no}"
         ids = [node_id]
 
         # Duplicate label warning
         if not label == "" and label in env.proof_list.keys():
-            path = env.doc2path(env.docname)[:-3]
+            docpath = env.doc2path(env.docname)
+            path = docpath[: docpath.rfind(".")]
             other_path = env.doc2path(env.proof_list[label]["docname"])
             msg = f"duplicate {typ} label '{label}', other instance in {other_path}"
             logger.warning(msg, location=path, color="red")
 
         title_text = ""
-        if self.arguments != []:
-            title_text += f" ({self.arguments[0]})"
 
-        textnodes, messages = self.state.inline_text(title_text, self.lineno)
+        if self.arguments != []:
+            if typ == "solution":
+                title_text = self.arguments[0]
+            else:
+                title_text += f" ({self.arguments[0]})"
+
+        if typ != "solution":
+            textnodes, messages = self.state.inline_text(title_text, self.lineno)
 
         section = nodes.section(classes=[f"{typ}-content"], ids=["proof-content"])
         self.state.nested_parse(self.content, self.content_offset, section)
@@ -79,7 +89,10 @@ class ElementDirective(SphinxDirective):
             node = enumerable_node()
 
         node.document = self.state.document
-        node += nodes.title(title_text, "", *textnodes)
+
+        if typ != "solution":
+            node += nodes.title(title_text, "", *textnodes)
+
         node += section
 
         # Set node attributes
@@ -96,6 +109,8 @@ class ElementDirective(SphinxDirective):
             "label": label,
             "prio": 0,
             "nonumber": True if "nonumber" in self.options else False,
+            "title": self.arguments[0] if self.arguments != [] else "",
+            "node": node,
         }
 
         return [node]
@@ -128,83 +143,5 @@ class ProofDirective(SphinxDirective):
 
         node = proof_node()
         node += section
-
-        return [node]
-
-
-class SolutionDirective(ElementDirective):
-    """A custom solution directive."""
-
-    name = "solution"
-    has_content = True
-    required_arguments = 1
-    optional_arguments = 0
-    final_argument_whitespace = False
-    option_spec = {
-        "label": directives.unchanged_required,
-        "class": directives.class_option,
-    }
-
-    def run(self) -> List[Node]:
-        env = self.env
-        domain_name, typ = self.name.split(":")[0], self.name.split(":")[1]
-        serial_no = env.new_serialno()
-
-        if not hasattr(env, "proof_list"):
-            env.proof_list = {}
-
-        if typ == "solution":
-            self.options["nonumber"] = True
-
-        # If class in options add to class array
-        classes, class_name = [domain_name, typ], self.options.get("class", [])
-        if class_name:
-            classes.extend(class_name)
-
-        label = self.options.get("label", "")
-        # If label
-        if label:
-            self.options["noindex"] = False
-            node_id = f"{label}"
-        else:
-            self.options["noindex"] = True
-            label = f"{typ}-{serial_no}"
-            node_id = f"{typ}-{serial_no}"
-        ids = [node_id]
-
-        # Duplicate label warning
-        if not label == "" and label in env.proof_list.keys():
-            path = env.doc2path(env.docname)[:-3]
-            other_path = env.doc2path(env.proof_list[label]["docname"])
-            msg = f"duplicate {typ} label '{label}', other instance in {other_path}"
-            logger.warning(msg, location=path, color="red")
-
-        title_text = self.arguments[0]
-
-        section = nodes.section(classes=[f"{typ}-content"], ids=["proof-content"])
-        self.state.nested_parse(self.content, self.content_offset, section)
-
-        node = unenumerable_node()
-
-        node.document = self.state.document
-        node += section
-
-        # Set node attributes
-        node["ids"].extend(ids)
-        node["classes"].extend(classes)
-        node["title"] = title_text
-        node["label"] = label
-        node["type"] = typ
-
-        env.proof_list[label] = {
-            "docname": env.docname,
-            "type": typ,
-            "ids": ids,
-            "label": label,
-            "prio": 0,
-            "nonumber": True if "nonumber" in self.options else False,
-        }
-
-        # import pdb; pdb.set_trace()
 
         return [node]

--- a/sphinxcontrib/prettyproof/directive.py
+++ b/sphinxcontrib/prettyproof/directive.py
@@ -41,6 +41,9 @@ class ElementDirective(SphinxDirective):
         if not hasattr(env, "proof_list"):
             env.proof_list = {}
 
+        # if typ == "solution":
+        #     option_spec["nonumber"] = True
+
         # If class in options add to class array
         classes, class_name = [domain_name, typ], self.options.get("class", [])
         if class_name:

--- a/sphinxcontrib/prettyproof/domain.py
+++ b/sphinxcontrib/prettyproof/domain.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from sphinx.domains import Domain, Index
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
+from docutils.utils.math import math2html
 from sphinx.util import logging
 from docutils import nodes
 from .directive import ProofDirective
@@ -140,13 +141,29 @@ class ProofDomain(Domain):
                         .get(ref_label, ())
                     )
                     number = ".".join(map(str, _))
-                    new_title = f"solution to {ref_match.get('type','').title()}"
+                    new_title = f"Solution to {ref_match.get('type','').title()}"
                 else:
                     if ref_match.get("title", "") == "":
                         new_title = f"Solution to {ref_match.get('type','').title()}"
                     else:
-                        # TODO: if title contains LaTeX
-                        new_title = f"Solution to {ref_match.get('title','')}"
+                        # Solution 1 - math2html
+                        exercise_node = env.proof_list[ref_label].get("node")
+                        exercise_node_title = exercise_node[0]
+
+                        exercise_title = ""
+                        for jj in range(len(exercise_node_title)):
+                            item = exercise_node_title[jj].astext()
+                            if type(exercise_node_title[jj]) == nodes.math:
+                                exercise_title += math2html.math2html(item)
+                                continue
+                            exercise_title += item
+
+                        right_idx, left_idx = (
+                            exercise_title.rfind(")"),
+                            exercise_title.find("(") + 1,
+                        )
+                        exercise_title = exercise_title[left_idx:right_idx]
+                        new_title = f"Solution to {exercise_title}"
 
             if number == "":
                 title = nodes.Text(f"{new_title}")

--- a/sphinxcontrib/prettyproof/domain.py
+++ b/sphinxcontrib/prettyproof/domain.py
@@ -19,7 +19,7 @@ from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
 from sphinx.util import logging
 from docutils import nodes
-from .directive import ProofDirective
+from .directive import ProofDirective, SolutionDirective
 from .proof_type import PROOF_TYPES
 
 logger = logging.getLogger(__name__)
@@ -75,7 +75,11 @@ class ProofDomain(Domain):
 
     indices = {ProofIndex}
 
-    directives = {**{"proof": ProofDirective}, **PROOF_TYPES}
+    directives = {
+        **{"proof": ProofDirective},
+        **{"solution": SolutionDirective},
+        **PROOF_TYPES,
+    }
 
     def resolve_xref(
         self,

--- a/sphinxcontrib/prettyproof/nodes.py
+++ b/sphinxcontrib/prettyproof/nodes.py
@@ -15,7 +15,7 @@ from docutils.nodes import Node
 logger = logging.getLogger(__name__)
 
 
-class proof_node(nodes.Admonition, nodes.Element):
+class default_node(nodes.Admonition, nodes.Element):
     pass
 
 
@@ -24,6 +24,10 @@ class enumerable_node(nodes.Admonition, nodes.Element):
 
 
 class unenumerable_node(nodes.Admonition, nodes.Element):
+    pass
+
+
+class linked_node(nodes.Admonition, nodes.Element):
     pass
 
 
@@ -45,107 +49,97 @@ def depart_enumerable_node(self, node: Node) -> None:
 def visit_unenumerable_node(self, node: Node) -> None:
     self.body.append(self.starttag(node, "div", CLASS="admonition"))
 
-    if node.get("type", "") == "solution":
-        env = self.builder.env
-        exercise_label = node.attributes.get("title", "")
-        self.body.append('<p class="admonition-title">')
-
-        # Check to see if exercise label exists
-        if exercise_label in env.proof_list.keys():
-            typ = env.proof_list[exercise_label].get("type", "")
-
-            # Check to see if exercise has nonumber
-            if env.proof_list[exercise_label].get("nonumber", bool):
-                # Check if title string in exercise is nonempty
-                exercise_title = env.proof_list[exercise_label].get("title", "")
-                if exercise_title == "":
-                    title = f'<a href="#{exercise_label}">Solution to {typ.title()}</a>'
-                    self.body.append(f"<span>{title}</span>")
-                else:
-                    # Retrieve exercise title
-                    atts = {}
-                    exercise_title = env.proof_list[exercise_label].get("node")[0]
-                    atts["href"] = "#" + exercise_label
-
-                    if len(exercise_title) == 1:
-                        # Retreive text item
-                        item = exercise_title[0]
-                        # Find and remove "(", ")" from title
-                        item_txt = item.astext()[
-                            item.astext().find("(") + 1 : item.astext().rfind(")")
-                        ]
-                        # Replace
-                        exercise_title.replace(item, nodes.Text(item_txt))
-                    else:
-                        # Retreive first text item
-                        first_item, last_item = exercise_title[0], exercise_title[-1]
-                        # Find and remove "(" and ")" from title
-                        first_txt = first_item.astext()[
-                            first_item.astext().find("(") + 1 :
-                        ]
-                        last_txt = last_item.astext()[: last_item.rfind(")")]
-                        # Replace
-                        exercise_title.replace(first_item, nodes.Text(first_txt))
-                        exercise_title.replace(last_item, nodes.Text(last_txt))
-
-                    self.body.append(
-                        self.starttag(exercise_title, "a", "Solution to ", **atts)
-                    )
-
-                    for item in exercise_title:
-                        if type(item) == nodes.math:
-                            # https://fossies.org/linux/Sphinx/sphinx/ext/mathjax.py
-                            self.body.append(
-                                self.starttag(
-                                    item,
-                                    "span",
-                                    "",
-                                    CLASS="math notranslate nohighlight",
-                                )
-                            )
-                            self.body.append(
-                                self.builder.config.mathjax_inline[0]
-                                + self.encode(item.astext())
-                                + self.builder.config.mathjax_inline[1]
-                                + "</span>"
-                            )
-                        else:
-                            self.body.append(item.astext())
-                    self.body.append("</a>")
-            else:
-                # Exercise is an enumerable node
-                number = get_node_number(self, exercise_label)
-                ref_node_title = f"{typ.title()} {number}"
-                title = f'<a href="#{exercise_label}">Solution to {ref_node_title}</a>'
-                self.body.append(f"<span>{title}</span>")
-        else:
-            # If label of exercise referenced in solution not found
-            docpath = env.doc2path(self.builder.current_docname)
-            path = docpath[: docpath.rfind(".")]
-            msg = f"label '{exercise_label}' not found"
-            logger.warning(msg, location=path, color="red")
-            title = f"Solution to {exercise_label}"
-            self.body.append(f"<span>{title}</span>")
-
-        self.body.append("</p>")
-
 
 def depart_unenumerable_node(self, node: Node) -> None:
     typ = node.attributes.get("type", "")
     idx = len(self.body) - self.body[-1::-1].index('<p class="admonition-title">')
 
-    if typ != "solution":
-        element = f"<span>{typ.title()} </span>"
-        self.body.insert(idx, element)
-
+    element = f"<span>{typ.title()} </span>"
+    self.body.insert(idx, element)
     self.body.append("</div>")
 
 
-def visit_proof_node(self, node: Node) -> None:
+def visit_linked_node(self, node: Node) -> None:
+
+    env = self.builder.env
+    linked_node_label = node.attributes.get("title", "")
+    node_type = node.attributes.get("type", "")
+
+    self.body.append(self.starttag(node, "div", CLASS="admonition"))
+    self.body.append('<p class="admonition-title">')
+
+    # Check to see if linked node label exists
+    if linked_node_label in env.proof_list.keys():
+        linked_node_typ = env.proof_list[linked_node_label].get("type", "")
+
+        # Check to see if linked node has nonumber
+        if env.proof_list[linked_node_label].get("nonumber", bool):
+            # Check if title string in linked node is nonempty
+            linked_node_title = env.proof_list[linked_node_label].get("title", "")
+            if linked_node_title == "":
+                title = f"<a href='#{linked_node_label}'>"
+                title += f"{node_type.title()} to {linked_node_typ.title()}</a>"
+                self.body.append(f"<span>{title}</span>")
+            else:
+                # Retrieve linked node title
+                atts = {}
+                linked_node_title = env.proof_list[linked_node_label].get("node")[0]
+                atts["href"] = "#" + linked_node_label
+
+                self.body.append(
+                    self.starttag(
+                        linked_node_title, "a", f"{node_type.title()} to ", **atts
+                    )
+                )
+
+                for item in linked_node_title:
+                    if type(item) == nodes.math:
+                        # https://fossies.org/linux/Sphinx/sphinx/ext/mathjax.py
+                        self.body.append(
+                            self.starttag(
+                                item,
+                                "span",
+                                "",
+                                CLASS="math notranslate nohighlight",
+                            )
+                        )
+                        self.body.append(
+                            self.builder.config.mathjax_inline[0]
+                            + self.encode(item.astext())
+                            + self.builder.config.mathjax_inline[1]
+                            + "</span>"
+                        )
+                    else:
+                        self.body.append(item.astext())
+                self.body.append("</a>")
+        else:
+            # Linked node is an enumerable node
+            number = get_node_number(self, linked_node_label)
+            ref_node_title = f"{linked_node_typ.title()} {number}"
+            title = f"<a href='#{linked_node_label}'>"
+            title += f"{node_type.title()} to {ref_node_title}</a>"
+            self.body.append(f"<span>{title}</span>")
+    else:
+        # If label of linked node referenced in current node not found
+        docpath = env.doc2path(self.builder.current_docname)
+        path = docpath[: docpath.rfind(".")]
+        msg = f"label '{linked_node_label}' not found"
+        logger.warning(msg, location=path, color="red")
+        title = f"{node_type.title()} to {linked_node_label}"
+        self.body.append(f"<span>{title}</span>")
+
+    self.body.append("</p>")
+
+
+def depart_linked_node(self, node: Node) -> None:
+    self.body.append("</div>")
+
+
+def visit_default_node(self, node: Node) -> None:
     pass
 
 
-def depart_proof_node(self, node: Node) -> None:
+def depart_default_node(self, node: Node) -> None:
     pass
 
 
@@ -153,3 +147,14 @@ def get_node_number(self: HTMLTranslator, attr: str) -> str:
     key = "proof"
     number = self.builder.fignumbers.get(key, {}).get(attr, ())
     return ".".join(map(str, number))
+
+
+nodes_collection = {
+    "default": (default_node, (visit_default_node, depart_default_node)),
+    "unenumerable": (
+        unenumerable_node,
+        (visit_unenumerable_node, depart_unenumerable_node),
+    ),
+    "enumerable": (enumerable_node, (visit_enumerable_node, depart_enumerable_node)),
+    "linked": (linked_node, (visit_linked_node, depart_linked_node)),
+}

--- a/sphinxcontrib/prettyproof/nodes.py
+++ b/sphinxcontrib/prettyproof/nodes.py
@@ -8,8 +8,11 @@ Enumerable and unenumerable nodes
 :licences: see LICENSE for details
 """
 from sphinx.builders.html import HTMLTranslator
+from sphinx.util import logging
 from docutils import nodes
 from docutils.nodes import Node
+
+logger = logging.getLogger(__name__)
 
 
 class proof_node(nodes.Admonition, nodes.Element):
@@ -30,9 +33,10 @@ def visit_enumerable_node(self, node: Node) -> None:
 
 def depart_enumerable_node(self, node: Node) -> None:
     typ = node.attributes.get("type", "")
+    ids = node.attributes.get("ids", [])[0]
 
     # Find index in list of 'Proof #'
-    number = get_node_number(self, node)
+    number = get_node_number(self, node, ids)
     idx = self.body.index(f"Proof {number} ")
     self.body[idx] = f"{typ.title()} {number} "
     self.body.append("</div>")
@@ -45,13 +49,37 @@ def visit_unenumerable_node(self, node: Node) -> None:
 def depart_unenumerable_node(self, node: Node) -> None:
     typ = node.attributes.get("type", "")
     title = node.attributes.get("title", "")
+    node_id = node.attributes.get("ids", [])[0]
 
-    if title == "":
-        idx = len(self.body) - self.body[-1::-1].index('<p class="admonition-title">')
+    if typ == "solution":
+        idx = [
+            ii for ii in range(len(self.body) - 1, -1, -1) if node_id in self.body[ii]
+        ][0] + 1
+        env = self.builder.env
+
+        if title in env.proof_list.keys():
+            # IF NONUMBER? If NONTITLE?
+            number = get_node_number(self, node, title)
+            title = (
+                f'<a href="#{title}">Solution to Exercise {number}</a>'  # add target
+            )
+        else:
+            # If label of exercise referenced in solution not found
+            path = env.doc2path(self.builder.current_docname)
+            msg = "label '{}' not found.".format(title)
+            logger.warning(msg, location=path, color="red")
+            title = "Solution to Exercise"
+
     else:
-        idx = self.body.index(title)
+        title = typ.title()
+        if title == "":
+            idx = len(self.body) - self.body[-1::-1].index(
+                '<p class="admonition-title">'
+            )
+        else:
+            idx = self.body.index(title)
 
-    element = f"<span>{typ.title()} </span>"
+    element = f"<span>{title} </span>"
     self.body.insert(idx, element)
     self.body.append("</div>")
 
@@ -64,8 +92,7 @@ def depart_proof_node(self, node: Node) -> None:
     pass
 
 
-def get_node_number(self: HTMLTranslator, node: Node) -> str:
+def get_node_number(self: HTMLTranslator, node: Node, attr: str) -> str:
     key = "proof"
-    ids = node.attributes.get("ids", [])[0]
-    number = self.builder.fignumbers.get(key, {}).get(ids, ())
+    number = self.builder.fignumbers.get(key, {}).get(attr, ())
     return ".".join(map(str, number))

--- a/sphinxcontrib/prettyproof/nodes.py
+++ b/sphinxcontrib/prettyproof/nodes.py
@@ -8,6 +8,7 @@ Enumerable and unenumerable nodes
 :licences: see LICENSE for details
 """
 from sphinx.builders.html import HTMLTranslator
+from docutils.utils.math import math2html
 from sphinx.util import logging
 from docutils import nodes
 from docutils.nodes import Node
@@ -60,6 +61,23 @@ def visit_unenumerable_node(self, node: Node) -> None:
                 if exercise_title == "":
                     title = f'<a href="#{exercise_label}">Solution to Exercise</a>'
                 else:
+                    # Solution 1 - math2html
+                    exercise_node = env.proof_list[exercise_label].get("node")
+                    exercise_node_title = exercise_node[0]
+
+                    exercise_title = ""
+                    for jj in range(len(exercise_node_title)):
+                        item = exercise_node_title[jj].astext()
+                        if type(exercise_node_title[jj]) == nodes.math:
+                            exercise_title += math2html.math2html(item)
+                            continue
+                        exercise_title += item
+
+                    right_idx, left_idx = (
+                        exercise_title.rfind(")"),
+                        exercise_title.find("(") + 1,
+                    )
+                    exercise_title = exercise_title[left_idx:right_idx]
                     title = (
                         f'<a href="#{exercise_label}">Solution to {exercise_title}</a>'
                     )
@@ -86,6 +104,9 @@ def depart_unenumerable_node(self, node: Node) -> None:
     if typ != "solution":
         element = f"<span>{typ.title()} </span>"
         self.body.insert(idx, element)
+    else:
+        # import pdb; pdb.set_trace()
+        pass
 
     self.body.append("</div>")
 

--- a/sphinxcontrib/prettyproof/nodes.py
+++ b/sphinxcontrib/prettyproof/nodes.py
@@ -52,13 +52,14 @@ def visit_unenumerable_node(self, node: Node) -> None:
 
         # Check to see if exercise label exists
         if exercise_label in env.proof_list.keys():
+            typ = env.proof_list[exercise_label].get("type", "")
 
             # Check to see if exercise has nonumber
             if env.proof_list[exercise_label].get("nonumber", bool):
                 # Check if title string in exercise is nonempty
                 exercise_title = env.proof_list[exercise_label].get("title", "")
                 if exercise_title == "":
-                    title = f'<a href="#{exercise_label}">Solution to Exercise</a>'
+                    title = f'<a href="#{exercise_label}">Solution to {typ.title()}</a>'
                     self.body.append(f"<span>{title}</span>")
                 else:
                     # Retrieve exercise title
@@ -114,7 +115,8 @@ def visit_unenumerable_node(self, node: Node) -> None:
             else:
                 # Exercise is an enumerable node
                 number = get_node_number(self, exercise_label)
-                title = f'<a href="#{exercise_label}">Solution to Exercise {number}</a>'
+                ref_node_title = f"{typ.title()} {number}"
+                title = f'<a href="#{exercise_label}">Solution to {ref_node_title}</a>'
                 self.body.append(f"<span>{title}</span>")
         else:
             # If label of exercise referenced in solution not found
@@ -122,7 +124,7 @@ def visit_unenumerable_node(self, node: Node) -> None:
             path = docpath[: docpath.rfind(".")]
             msg = f"label '{exercise_label}' not found"
             logger.warning(msg, location=path, color="red")
-            title = "Solution to Exercise"
+            title = f"Solution to {exercise_label}"
             self.body.append(f"<span>{title}</span>")
 
         self.body.append("</p>")

--- a/sphinxcontrib/prettyproof/proof_type.py
+++ b/sphinxcontrib/prettyproof/proof_type.py
@@ -95,6 +95,15 @@ class PropositionDirective(ElementDirective):
     name = "proposition"
 
 
+class SolutionDirective(ElementDirective):
+    """A custom solution directive."""
+
+    name = "solution"
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+
+
 PROOF_TYPES = {
     "axiom": AxiomDirective,
     "theorem": TheoremDirective,
@@ -110,4 +119,5 @@ PROOF_TYPES = {
     "property": PropertyDirective,
     "observation": ObservationDirective,
     "proposition": PropositionDirective,
+    "solution": SolutionDirective,
 }

--- a/sphinxcontrib/prettyproof/proof_type.py
+++ b/sphinxcontrib/prettyproof/proof_type.py
@@ -8,8 +8,7 @@ List of proof-type directives
 :licences: see LICENSE for details
 """
 
-from docutils.parsers.rst import directives
-from .directive import ElementDirective
+from .directive import ElementDirective, LinkedDirective
 
 
 class TheoremDirective(ElementDirective):
@@ -96,17 +95,10 @@ class PropositionDirective(ElementDirective):
     name = "proposition"
 
 
-class SolutionDirective(ElementDirective):
+class SolutionDirective(LinkedDirective):
     """A custom solution directive."""
 
     name = "solution"
-    required_arguments = 1
-    optional_arguments = 0
-    final_argument_whitespace = False
-    option_spec = {
-        "label": directives.unchanged_required,
-        "class": directives.class_option,
-    }
 
 
 PROOF_TYPES = {

--- a/sphinxcontrib/prettyproof/proof_type.py
+++ b/sphinxcontrib/prettyproof/proof_type.py
@@ -8,6 +8,7 @@ List of proof-type directives
 :licences: see LICENSE for details
 """
 
+from docutils.parsers.rst import directives
 from .directive import ElementDirective
 
 
@@ -95,6 +96,19 @@ class PropositionDirective(ElementDirective):
     name = "proposition"
 
 
+class SolutionDirective(ElementDirective):
+    """A custom solution directive."""
+
+    name = "solution"
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {
+        "label": directives.unchanged_required,
+        "class": directives.class_option,
+    }
+
+
 PROOF_TYPES = {
     "axiom": AxiomDirective,
     "theorem": TheoremDirective,
@@ -110,4 +124,5 @@ PROOF_TYPES = {
     "property": PropertyDirective,
     "observation": ObservationDirective,
     "proposition": PropositionDirective,
+    "solution": SolutionDirective,
 }

--- a/sphinxcontrib/prettyproof/proof_type.py
+++ b/sphinxcontrib/prettyproof/proof_type.py
@@ -95,15 +95,6 @@ class PropositionDirective(ElementDirective):
     name = "proposition"
 
 
-class SolutionDirective(ElementDirective):
-    """A custom solution directive."""
-
-    name = "solution"
-    required_arguments = 1
-    optional_arguments = 0
-    final_argument_whitespace = False
-
-
 PROOF_TYPES = {
     "axiom": AxiomDirective,
     "theorem": TheoremDirective,
@@ -119,5 +110,4 @@ PROOF_TYPES = {
     "property": PropertyDirective,
     "observation": ObservationDirective,
     "proposition": PropositionDirective,
-    "solution": SolutionDirective,
 }

--- a/tests/books/test-mybook/algorithm/_algo_labeled_titled_with_classname.rst
+++ b/tests/books/test-mybook/algorithm/_algo_labeled_titled_with_classname.rst
@@ -1,5 +1,5 @@
-content 1
-=========
+_algo_labeled_titled_with_classname
+===================================
 
 .. proof:algorithm:: Test algorithm directive
 	:class: test-algo

--- a/tests/books/test-mybook/algorithm/_algo_numbered_reference.rst
+++ b/tests/books/test-mybook/algorithm/_algo_numbered_reference.rst
@@ -1,4 +1,4 @@
-content 3
-=========
+_algo_numbered_reference
+========================
 
 referencing with number :proof:ref:`test-algo-label`.

--- a/tests/books/test-mybook/algorithm/_algo_text_reference.rst
+++ b/tests/books/test-mybook/algorithm/_algo_text_reference.rst
@@ -1,4 +1,4 @@
-content 4
-=========
+_algo_text_reference
+====================
 
 referencing with text: :proof:ref:`text <test-algo-label>`.

--- a/tests/books/test-mybook/algorithm/_algo_title_with_inline_math.rst
+++ b/tests/books/test-mybook/algorithm/_algo_title_with_inline_math.rst
@@ -1,7 +1,6 @@
-_algo_nonumber
-==============
+_algo_title_with_inline_math
+============================
 
-.. proof:algorithm:: Test algorithm directive
-	:nonumber:
+.. proof:algorithm:: Test :math:`\mathbb{R}`
 
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/books/test-mybook/algorithm/_algo_unlabeled_math.rst
+++ b/tests/books/test-mybook/algorithm/_algo_unlabeled_math.rst
@@ -1,7 +1,10 @@
-_algo_nonumber
-==============
+_algo_unlabeled_math
+====================
 
 .. proof:algorithm:: Test algorithm directive
-	:nonumber:
 
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+	.. math::
+
+		P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)

--- a/tests/books/test-mybook/algorithm/_algo_with_labeled_math.rst
+++ b/tests/books/test-mybook/algorithm/_algo_with_labeled_math.rst
@@ -1,7 +1,11 @@
-_algo_nonumber
-==============
+_algo_with_labeled_math
+=======================
 
 .. proof:algorithm:: Test algorithm directive
-	:nonumber:
 
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+	.. math::
+		:label: label3
+
+		P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)

--- a/tests/books/test-mybook/index.rst
+++ b/tests/books/test-mybook/index.rst
@@ -22,11 +22,13 @@ A Test Program!
    solution/_solution_ref_with_nonumber_notitle
    solution/_solution_ref_with_nonumber_title
    solution/_solution_ref_with_nonumber_title_inlinemath
+   solution/_solution_ref_with_nonumber_title_inlinemath2
    solution/_solution_ref_with_number
    solution/_solution_ref_wrong_solution_ref
    solution/_solution_with_exercise_nonumber_notitle
    solution/_solution_with_exercise_nonumber_title
    solution/_solution_with_exercise_nonumber_title_inlinemath
+   solution/_solution_with_exercise_nonumber_title_inlinemath2
    solution/_solution_with_exercise_number
    solution/_solution_with_label_and_class
    solution/_solution_with_wrong_exlabel

--- a/tests/books/test-mybook/index.rst
+++ b/tests/books/test-mybook/index.rst
@@ -18,6 +18,7 @@ A Test Program!
    proof/_proof_with_unlabeled_math
    proof/_proof_with_argument_content
    proof/_proof_inline_math_argument
+   solution/_solution_with_duplicate_label
    solution/_solution_missing_arg
    solution/_solution_ref_with_nonumber_notitle
    solution/_solution_ref_with_nonumber_title

--- a/tests/books/test-mybook/index.rst
+++ b/tests/books/test-mybook/index.rst
@@ -9,8 +9,24 @@ A Test Program!
    algorithm/_algo_labeled_titled_with_classname
    algorithm/_algo_numbered_reference
    algorithm/_algo_text_reference
+   algorithm/_algo_title_with_inline_math
+   algorithm/_algo_with_labeled_math
+   algorithm/_algo_unlabeled_math
    proof/_proof_with_classname
    proof/_proof_with_labeled_math
    proof/_proof_no_classname
    proof/_proof_with_unlabeled_math
    proof/_proof_with_argument_content
+   proof/_proof_inline_math_argument
+   solution/_solution_missing_arg
+   solution/_solution_ref_with_nonumber_notitle
+   solution/_solution_ref_with_nonumber_title
+   solution/_solution_ref_with_nonumber_title_inlinemath
+   solution/_solution_ref_with_number
+   solution/_solution_ref_wrong_solution_ref
+   solution/_solution_with_exercise_nonumber_notitle
+   solution/_solution_with_exercise_nonumber_title
+   solution/_solution_with_exercise_nonumber_title_inlinemath
+   solution/_solution_with_exercise_number
+   solution/_solution_with_label_and_class
+   solution/_solution_with_wrong_exlabel

--- a/tests/books/test-mybook/proof/_proof_inline_math_argument.rst
+++ b/tests/books/test-mybook/proof/_proof_inline_math_argument.rst
@@ -1,7 +1,7 @@
-_proof_with_argument_content
-============================
+_proof_inline_math_argument
+===========================
 
-.. proof:proof:: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+.. proof:proof:: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. :math:`\mathbb{R}`.
 
     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/books/test-mybook/proof/_proof_no_classname.rst
+++ b/tests/books/test-mybook/proof/_proof_no_classname.rst
@@ -1,5 +1,5 @@
-content 2
-=========
+_proof_no_classname
+===================
 
 .. proof:proof::
 

--- a/tests/books/test-mybook/proof/_proof_with_classname.rst
+++ b/tests/books/test-mybook/proof/_proof_with_classname.rst
@@ -1,5 +1,5 @@
-content 1
-=========
+_proof_with_classname
+=====================
 
 .. proof:proof::
     :class: test-proof

--- a/tests/books/test-mybook/proof/_proof_with_labeled_math.rst
+++ b/tests/books/test-mybook/proof/_proof_with_labeled_math.rst
@@ -1,5 +1,5 @@
-content 4
-=========
+_proof_with_labeled_math
+========================
 
 .. proof:proof::
 

--- a/tests/books/test-mybook/proof/_proof_with_unlabeled_math.rst
+++ b/tests/books/test-mybook/proof/_proof_with_unlabeled_math.rst
@@ -1,5 +1,5 @@
-content 3
-=========
+_proof_with_unlabeled_math
+==========================
 
 .. proof:proof::
 

--- a/tests/books/test-mybook/solution/_solution_missing_arg.rst
+++ b/tests/books/test-mybook/solution/_solution_missing_arg.rst
@@ -1,0 +1,6 @@
+_solution_missing_arg
+=====================
+
+.. proof:solution::
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/books/test-mybook/solution/_solution_ref_with_nonumber_notitle.rst
+++ b/tests/books/test-mybook/solution/_solution_ref_with_nonumber_notitle.rst
@@ -1,0 +1,7 @@
+_solution_ref_with_nonumber_notitle
+===================================
+
+
+referencing: :proof:ref:`sol-nonumber-notitle`.
+
+referencing: :proof:ref:`ex with nonumber and notitle <sol-nonumber-notitle>`.

--- a/tests/books/test-mybook/solution/_solution_ref_with_nonumber_title.rst
+++ b/tests/books/test-mybook/solution/_solution_ref_with_nonumber_title.rst
@@ -1,0 +1,7 @@
+_solution_ref_with_nonumber_title
+=================================
+
+
+referencing: :proof:ref:`sol-nonumber-title`.
+
+referencing: :proof:ref:`exercise with nonumber but with title <sol-nonumber-title>`.

--- a/tests/books/test-mybook/solution/_solution_ref_with_nonumber_title_inlinemath.rst
+++ b/tests/books/test-mybook/solution/_solution_ref_with_nonumber_title_inlinemath.rst
@@ -2,6 +2,6 @@ _solution_ref_with_nonumber_title_inlinemath
 ============================================
 
 
-.. referencing: :proof:ref:`sol-nonumber-title-math`.
+referencing: :proof:ref:`sol-nonumber-title-math`.
 
-.. referencing: :proof:ref:`exercise with nonumber but with inline math title <sol-nonumber-title-math>`.
+referencing: :proof:ref:`exercise with nonumber but with inline math title <sol-nonumber-title-math>`.

--- a/tests/books/test-mybook/solution/_solution_ref_with_nonumber_title_inlinemath.rst
+++ b/tests/books/test-mybook/solution/_solution_ref_with_nonumber_title_inlinemath.rst
@@ -1,0 +1,7 @@
+_solution_ref_with_nonumber_title_inlinemath
+============================================
+
+
+.. referencing: :proof:ref:`sol-nonumber-title-math`.
+
+.. referencing: :proof:ref:`exercise with nonumber but with inline math title <sol-nonumber-title-math>`.

--- a/tests/books/test-mybook/solution/_solution_ref_with_nonumber_title_inlinemath2.rst
+++ b/tests/books/test-mybook/solution/_solution_ref_with_nonumber_title_inlinemath2.rst
@@ -1,0 +1,7 @@
+_solution_ref_with_nonumber_title_inlinemath2
+=============================================
+
+
+referencing: :proof:ref:`sol-nonumber-title-math2`.
+
+referencing: :proof:ref:`exercise with nonumber but with inline math title ex2 <sol-nonumber-title-math2>`.

--- a/tests/books/test-mybook/solution/_solution_ref_with_number.rst
+++ b/tests/books/test-mybook/solution/_solution_ref_with_number.rst
@@ -1,0 +1,7 @@
+_solution_ref_with_number
+=========================
+
+
+referencing: :proof:ref:`sol-number`.
+
+referencing: :proof:ref:`simple solution with number <sol-number>`.

--- a/tests/books/test-mybook/solution/_solution_ref_wrong_solution_ref.rst
+++ b/tests/books/test-mybook/solution/_solution_ref_wrong_solution_ref.rst
@@ -1,0 +1,5 @@
+_solution_ref_wrong_solution_ref
+================================
+
+
+referencing: :proof:ref:`foobar`.

--- a/tests/books/test-mybook/solution/_solution_with_duplicate_label.rst
+++ b/tests/books/test-mybook/solution/_solution_with_duplicate_label.rst
@@ -1,0 +1,14 @@
+_solution_with_duplicate_label
+==============================
+
+
+
+.. proof:solution:: ex-nonumber-notitle
+	:label: sol-duplicate-label
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+.. proof:solution:: ex-nonumber-notitle
+	:label: sol-duplicate-label
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_notitle.rst
+++ b/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_notitle.rst
@@ -1,0 +1,19 @@
+_solution_with_exercise_nonumber_notitle
+========================================
+
+
+.. proof:exercise::
+	:label: ex-nonumber-notitle
+	:nonumber:
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+	Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+	Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+.. proof:solution:: ex-nonumber-notitle
+	:label: sol-nonumber-notitle
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_title.rst
+++ b/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_title.rst
@@ -1,0 +1,19 @@
+_solution_with_exercise_nonumber_title
+======================================
+
+
+.. proof:exercise:: This is a title
+	:label: ex-nonumber-title
+	:nonumber:
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+	Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+	Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+.. proof:solution:: ex-nonumber-title
+	:label: sol-nonumber-title
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_title_inlinemath.rst
+++ b/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_title_inlinemath.rst
@@ -1,0 +1,19 @@
+_solution_with_exercise_nonumber_title_inlinemath
+=================================================
+
+
+.. proof:exercise:: This is a title :math:`\mathbb{R}`
+	:label: ex-nonumber-title-math
+	:nonumber:
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+	Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+	Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+.. .. proof:solution:: ex-nonumber-title-math
+.. 	:label: sol-nonumber-title-math
+
+.. 	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_title_inlinemath.rst
+++ b/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_title_inlinemath.rst
@@ -13,7 +13,7 @@ _solution_with_exercise_nonumber_title_inlinemath
 	Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 
-.. .. proof:solution:: ex-nonumber-title-math
-.. 	:label: sol-nonumber-title-math
+.. proof:solution:: ex-nonumber-title-math
+	:label: sol-nonumber-title-math
 
-.. 	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_title_inlinemath2.rst
+++ b/tests/books/test-mybook/solution/_solution_with_exercise_nonumber_title_inlinemath2.rst
@@ -1,0 +1,19 @@
+_solution_with_exercise_nonumber_title_inlinemath2
+==================================================
+
+
+.. proof:exercise:: This is a title :math:`P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)`
+	:label: ex-nonumber-title-math2
+	:nonumber:
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+	Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+	Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+.. proof:solution:: ex-nonumber-title-math2
+	:label: sol-nonumber-title-math2
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/books/test-mybook/solution/_solution_with_exercise_number.rst
+++ b/tests/books/test-mybook/solution/_solution_with_exercise_number.rst
@@ -1,0 +1,29 @@
+_solution_with_exercise_number
+==============================
+
+
+.. proof:exercise:: This is a title
+	:label: ex-number
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+	Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+	Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+.. proof:solution:: ex-number
+	:label: sol-number
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+	.. math::
+
+		P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)
+
+	Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+	.. math::
+		:label: ex-math
+
+		P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)

--- a/tests/books/test-mybook/solution/_solution_with_label_and_class.rst
+++ b/tests/books/test-mybook/solution/_solution_with_label_and_class.rst
@@ -1,0 +1,8 @@
+_solution_with_label_and_class
+==============================
+
+.. proof:solution:: ex-number
+	:label: solution-label
+	:class: test-solution
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/books/test-mybook/solution/_solution_with_wrong_exlabel.rst
+++ b/tests/books/test-mybook/solution/_solution_with_wrong_exlabel.rst
@@ -1,0 +1,6 @@
+_solution_with_wrong_exlabel
+============================
+
+.. proof:solution:: wrong-ex-label
+
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -4,13 +4,24 @@ import pytest
 
 @pytest.mark.sphinx("html", testroot="mybook")
 @pytest.mark.parametrize(
-    "idir", ["_algo_labeled_titled_with_classname.html", "_algo_nonumber.html"]
+    "idir",
+    [
+        "_algo_labeled_titled_with_classname.html",
+        "_algo_nonumber.html",
+        "_algo_title_with_inline_math.html",
+        "_algo_unlabeled_math.html",
+        "_algo_with_labeled_math.html",
+    ],
 )
 def test_algorithm(app, idir, file_regression):
     """Test algorithm directive markup."""
     app.build()
     path_algo_directive = app.outdir / "algorithm" / idir
     assert path_algo_directive.exists()
+
+    import pdb
+
+    pdb.set_trace()
 
     # get content markup
     soup = BeautifulSoup(path_algo_directive.read_text(encoding="utf8"), "html.parser")

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -19,10 +19,6 @@ def test_algorithm(app, idir, file_regression):
     path_algo_directive = app.outdir / "algorithm" / idir
     assert path_algo_directive.exists()
 
-    import pdb
-
-    pdb.set_trace()
-
     # get content markup
     soup = BeautifulSoup(path_algo_directive.read_text(encoding="utf8"), "html.parser")
     algo = soup.select("div.algorithm")[0]

--- a/tests/test_algorithm/_algo_title_with_inline_math.html
+++ b/tests/test_algorithm/_algo_title_with_inline_math.html
@@ -1,5 +1,5 @@
-<div class="proof algorithm admonition" id="algorithm/_algo_nonumber-algorithm-0">
-<p class="admonition-title"><span>Algorithm </span> (Test algorithm directive)</p>
+<div class="proof algorithm admonition" id="algorithm/_algo_title_with_inline_math-algorithm-0">
+<p class="admonition-title"><span class="caption-number">Algorithm 2 </span> (Test <span class="math notranslate nohighlight">\(\mathbb{R}\)</span>)</p>
 <div class="algorithm-content section" id="proof-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 </div>

--- a/tests/test_algorithm/_algo_unlabeled_math.html
+++ b/tests/test_algorithm/_algo_unlabeled_math.html
@@ -1,6 +1,8 @@
-<div class="proof algorithm admonition" id="algorithm/_algo_nonumber-algorithm-0">
-<p class="admonition-title"><span>Algorithm </span> (Test algorithm directive)</p>
+<div class="proof algorithm admonition" id="algorithm/_algo_unlabeled_math-algorithm-0">
+<p class="admonition-title"><span class="caption-number">Algorithm 4 </span> (Test algorithm directive)</p>
 <div class="algorithm-content section" id="proof-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<div class="math notranslate nohighlight">
+\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
 </div>
 </div>

--- a/tests/test_algorithm/_algo_with_labeled_math.html
+++ b/tests/test_algorithm/_algo_with_labeled_math.html
@@ -1,6 +1,8 @@
-<div class="proof algorithm admonition" id="algorithm/_algo_nonumber-algorithm-0">
-<p class="admonition-title"><span>Algorithm </span> (Test algorithm directive)</p>
+<div class="proof algorithm admonition" id="algorithm/_algo_with_labeled_math-algorithm-0">
+<p class="admonition-title"><span class="caption-number">Algorithm 3 </span> (Test algorithm directive)</p>
 <div class="algorithm-content section" id="proof-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<div class="math notranslate nohighlight" id="equation-label3">
+<span class="eqno">(1)<a class="headerlink" href="#equation-label3" title="Permalink to this equation">¶</a></span>\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
 </div>
 </div>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -8,6 +8,7 @@ def test_build(app):
     assert (app.outdir / "index.html").exists()
     assert (app.outdir / "algorithm").exists()
     assert (app.outdir / "proof").exists()
+    assert (app.outdir / "solution").exists()
 
 
 @pytest.mark.sphinx("html", testroot="missingref")

--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -11,6 +11,7 @@ import pytest
         "_proof_with_argument_content.html",
         "_proof_with_labeled_math.html",
         "_proof_with_unlabeled_math.html",
+        "_proof_inline_math_argument.html",
     ],
 )
 def test_proof(app, idir, file_regression):

--- a/tests/test_proof/_proof_inline_math_argument.html
+++ b/tests/test_proof/_proof_inline_math_argument.html
@@ -1,0 +1,5 @@
+<div class="proof admonition" id="proof">
+<p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. <span class="math notranslate nohighlight">\(\mathbb{R}\)</span>.</p>
+<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>

--- a/tests/test_proof/_proof_with_labeled_math.html
+++ b/tests/test_proof/_proof_with_labeled_math.html
@@ -1,5 +1,5 @@
 <div class="proof admonition" id="proof">
 <p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut</p>
 <div class="math notranslate nohighlight" id="equation-label1">
-<span class="eqno">(1)<a class="headerlink" href="#equation-label1" title="Permalink to this equation">¶</a></span>\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
+<span class="eqno">(2)<a class="headerlink" href="#equation-label1" title="Permalink to this equation">¶</a></span>\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
 </div>

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -1,0 +1,58 @@
+from bs4 import BeautifulSoup
+import pytest
+
+
+@pytest.mark.sphinx("html", testroot="mybook")
+@pytest.mark.parametrize(
+    "idir",
+    [
+        "_solution_with_exercise_nonumber_notitle.html",
+        "_solution_with_exercise_nonumber_title.html",
+        # "_solution_with_exercise_nonumber_title_inlinemath.html",
+        "_solution_with_exercise_number.html",
+        "_solution_with_label_and_class.html",
+    ],
+)
+def test_solution(app, idir, file_regression):
+    """Test solution directive markup."""
+    app.build()
+    path_solution_directive = app.outdir / "solution" / idir
+    assert path_solution_directive.exists()
+
+    # get content markup
+    soup = BeautifulSoup(
+        path_solution_directive.read_text(encoding="utf8"), "html.parser"
+    )
+    sol = soup.select("div.solution")[0]
+    file_regression.check(str(sol), basename=idir.split(".")[0], extension=".html")
+
+
+@pytest.mark.sphinx("html", testroot="mybook")
+@pytest.mark.parametrize(
+    "idir",
+    [
+        "",
+        "",
+        "",
+    ],
+)
+def test_reference(app, idir, file_regression):
+    """Test solution ref role markup."""
+    app.builder.build_all()
+    path_solution_directive = app.outdir / "solution" / idir
+    assert path_solution_directive.exists()
+    # get content markup
+    soup = BeautifulSoup(
+        path_solution_directive.read_text(encoding="utf8"), "html.parser"
+    )
+
+    sol = soup.select("p")[0]
+    file_regression.check(str(sol), basename=idir.split(".")[0], extension=".html")
+
+
+@pytest.mark.sphinx("html", testroot="mybook")
+def test_warnings(app, warnings):
+    app.build()
+    assert "WARNING: label 'foobar' not found" in warnings(app)
+    assert "WARNING: label 'wrong-ex-label' not found." in warnings(app)
+    assert 'WARNING: Error in "proof:solution" directive' in warnings(app)

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -20,6 +20,7 @@ def test_warnings(app, warnings):
         "_solution_with_exercise_nonumber_notitle.html",
         "_solution_with_exercise_nonumber_title.html",
         "_solution_with_exercise_nonumber_title_inlinemath.html",
+        "_solution_with_exercise_nonumber_title_inlinemath2.html",
         "_solution_with_exercise_number.html",
         "_solution_with_label_and_class.html",
     ],
@@ -45,7 +46,8 @@ def test_solution(app, idir, file_regression):
     [
         "_solution_ref_with_nonumber_notitle.html",
         "_solution_ref_with_nonumber_title.html",
-        # "_solution_ref_with_nonumber_title_inlinemath",
+        "_solution_ref_with_nonumber_title_inlinemath.html",
+        "_solution_ref_with_nonumber_title_inlinemath2.html",
         "_solution_ref_with_number.html",
         "_solution_ref_wrong_solution_ref.html",
     ],

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -11,6 +11,7 @@ def test_warnings(app, warnings):
     assert "WARNING: label 'foobar' not found" in warnings(app)
     assert "WARNING: label 'wrong-ex-label' not found" in warnings(app)
     assert 'WARNING: Error in "proof:solution" directive' in warnings(app)
+    assert "WARNING: duplicate solution label 'sol-duplicate-label'" in warnings(app)
 
 
 @pytest.mark.sphinx("html", testroot="mybook")

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -1,9 +1,12 @@
 from bs4 import BeautifulSoup
 import pytest
+import shutil
 
 
 @pytest.mark.sphinx("html", testroot="mybook")
 def test_warnings(app, warnings):
+    build_path = app.srcdir.joinpath("_build")
+    shutil.rmtree(build_path)
     app.build()
     assert "WARNING: label 'foobar' not found" in warnings(app)
     assert "WARNING: label 'wrong-ex-label' not found" in warnings(app)
@@ -16,7 +19,7 @@ def test_warnings(app, warnings):
     [
         "_solution_with_exercise_nonumber_notitle.html",
         "_solution_with_exercise_nonumber_title.html",
-        # "_solution_with_exercise_nonumber_title_inlinemath.html",
+        "_solution_with_exercise_nonumber_title_inlinemath.html",
         "_solution_with_exercise_number.html",
         "_solution_with_label_and_class.html",
     ],

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -3,6 +3,14 @@ import pytest
 
 
 @pytest.mark.sphinx("html", testroot="mybook")
+def test_warnings(app, warnings):
+    app.build()
+    assert "WARNING: label 'foobar' not found" in warnings(app)
+    assert "WARNING: label 'wrong-ex-label' not found" in warnings(app)
+    assert 'WARNING: Error in "proof:solution" directive' in warnings(app)
+
+
+@pytest.mark.sphinx("html", testroot="mybook")
 @pytest.mark.parametrize(
     "idir",
     [
@@ -23,6 +31,7 @@ def test_solution(app, idir, file_regression):
     soup = BeautifulSoup(
         path_solution_directive.read_text(encoding="utf8"), "html.parser"
     )
+
     sol = soup.select("div.solution")[0]
     file_regression.check(str(sol), basename=idir.split(".")[0], extension=".html")
 
@@ -31,9 +40,11 @@ def test_solution(app, idir, file_regression):
 @pytest.mark.parametrize(
     "idir",
     [
-        "",
-        "",
-        "",
+        "_solution_ref_with_nonumber_notitle.html",
+        "_solution_ref_with_nonumber_title.html",
+        # "_solution_ref_with_nonumber_title_inlinemath",
+        "_solution_ref_with_number.html",
+        "_solution_ref_wrong_solution_ref.html",
     ],
 )
 def test_reference(app, idir, file_regression):
@@ -46,13 +57,8 @@ def test_reference(app, idir, file_regression):
         path_solution_directive.read_text(encoding="utf8"), "html.parser"
     )
 
-    sol = soup.select("p")[0]
-    file_regression.check(str(sol), basename=idir.split(".")[0], extension=".html")
-
-
-@pytest.mark.sphinx("html", testroot="mybook")
-def test_warnings(app, warnings):
-    app.build()
-    assert "WARNING: label 'foobar' not found" in warnings(app)
-    assert "WARNING: label 'wrong-ex-label' not found." in warnings(app)
-    assert 'WARNING: Error in "proof:solution" directive' in warnings(app)
+    if idir == "_solution_ref_wrong_solution_ref.html":
+        sol = str(soup.select("p")[0])
+    else:
+        sol = f'{soup.select("p")[0]}\n{soup.select("p")[1]}'
+    file_regression.check(sol, basename=idir.split(".")[0], extension=".html")

--- a/tests/test_solution/_solution_ref_with_nonumber_notitle.html
+++ b/tests/test_solution/_solution_ref_with_nonumber_notitle.html
@@ -1,0 +1,2 @@
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_notitle.html#sol-nonumber-notitle">Solution to Exercise</a>.</p>
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_notitle.html#sol-nonumber-notitle">ex with nonumber and notitle</a>.</p>

--- a/tests/test_solution/_solution_ref_with_nonumber_title.html
+++ b/tests/test_solution/_solution_ref_with_nonumber_title.html
@@ -1,0 +1,2 @@
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title.html#sol-nonumber-title">Solution to This is a title</a>.</p>
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title.html#sol-nonumber-title">exercise with nonumber but with title</a>.</p>

--- a/tests/test_solution/_solution_ref_with_nonumber_title.html
+++ b/tests/test_solution/_solution_ref_with_nonumber_title.html
@@ -1,2 +1,2 @@
-<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title.html#sol-nonumber-title">Solution to This is a title</a>.</p>
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title.html#sol-nonumber-title"><span>Solution to This is a title</span></a>.</p>
 <p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title.html#sol-nonumber-title">exercise with nonumber but with title</a>.</p>

--- a/tests/test_solution/_solution_ref_with_nonumber_title_inlinemath.html
+++ b/tests/test_solution/_solution_ref_with_nonumber_title_inlinemath.html
@@ -1,0 +1,2 @@
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title_inlinemath.html#sol-nonumber-title-math">Solution to  This is a title ℝ</a>.</p>
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title_inlinemath.html#sol-nonumber-title-math">exercise with nonumber but with inline math title</a>.</p>

--- a/tests/test_solution/_solution_ref_with_nonumber_title_inlinemath.html
+++ b/tests/test_solution/_solution_ref_with_nonumber_title_inlinemath.html
@@ -1,2 +1,2 @@
-<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title_inlinemath.html#sol-nonumber-title-math">Solution to  This is a title ℝ</a>.</p>
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title_inlinemath.html#sol-nonumber-title-math"><span>Solution to This is a title <span class="math notranslate nohighlight">\(\mathbb{R}\)</span></span></a>.</p>
 <p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title_inlinemath.html#sol-nonumber-title-math">exercise with nonumber but with inline math title</a>.</p>

--- a/tests/test_solution/_solution_ref_with_nonumber_title_inlinemath2.html
+++ b/tests/test_solution/_solution_ref_with_nonumber_title_inlinemath2.html
@@ -1,0 +1,2 @@
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title_inlinemath2.html#sol-nonumber-title-math2"><span>Solution to This is a title <span class="math notranslate nohighlight">\(P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\)</span></span></a>.</p>
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_nonumber_title_inlinemath2.html#sol-nonumber-title-math2">exercise with nonumber but with inline math title ex2</a>.</p>

--- a/tests/test_solution/_solution_ref_with_number.html
+++ b/tests/test_solution/_solution_ref_with_number.html
@@ -1,0 +1,2 @@
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_number.html#sol-number">solution to Exercise 5</a>.</p>
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_number.html#sol-number">simple solution with number</a>.</p>

--- a/tests/test_solution/_solution_ref_with_number.html
+++ b/tests/test_solution/_solution_ref_with_number.html
@@ -1,2 +1,2 @@
-<p>referencing: <a class="reference internal" href="_solution_with_exercise_number.html#sol-number">solution to Exercise 5</a>.</p>
+<p>referencing: <a class="reference internal" href="_solution_with_exercise_number.html#sol-number">Solution to Exercise 5</a>.</p>
 <p>referencing: <a class="reference internal" href="_solution_with_exercise_number.html#sol-number">simple solution with number</a>.</p>

--- a/tests/test_solution/_solution_ref_wrong_solution_ref.html
+++ b/tests/test_solution/_solution_ref_wrong_solution_ref.html
@@ -1,0 +1,1 @@
+<p>referencing: <code class="xref proof proof-ref docutils literal notranslate"><span class="pre">foobar</span></code>.</p>

--- a/tests/test_solution/_solution_with_exercise_nonumber_notitle.html
+++ b/tests/test_solution/_solution_with_exercise_nonumber_notitle.html
@@ -1,0 +1,5 @@
+<div class="proof solution admonition" id="sol-nonumber-notitle">
+<p class="admonition-title"><span><a href="#ex-nonumber-notitle">Solution to Exercise</a></p> </span><div class="solution-content section" id="proof-content">
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</div>
+</div>

--- a/tests/test_solution/_solution_with_exercise_nonumber_notitle.html
+++ b/tests/test_solution/_solution_with_exercise_nonumber_notitle.html
@@ -1,5 +1,5 @@
 <div class="proof solution admonition" id="sol-nonumber-notitle">
-<p class="admonition-title"><span><a href="#ex-nonumber-notitle">Solution to Exercise</a></p> </span><div class="solution-content section" id="proof-content">
+<p class="admonition-title"><span><a href="#ex-nonumber-notitle">Solution to Exercise</a></span></p><div class="solution-content section" id="proof-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>
 </div>

--- a/tests/test_solution/_solution_with_exercise_nonumber_title.html
+++ b/tests/test_solution/_solution_with_exercise_nonumber_title.html
@@ -1,0 +1,5 @@
+<div class="proof solution admonition" id="sol-nonumber-title">
+<p class="admonition-title"><span><a href="#ex-nonumber-title">Solution to This is a title</a></p> </span><div class="solution-content section" id="proof-content">
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</div>
+</div>

--- a/tests/test_solution/_solution_with_exercise_nonumber_title.html
+++ b/tests/test_solution/_solution_with_exercise_nonumber_title.html
@@ -1,5 +1,5 @@
 <div class="proof solution admonition" id="sol-nonumber-title">
-<p class="admonition-title"><span><a href="#ex-nonumber-title">Solution to This is a title</a></span></p><div class="solution-content section" id="proof-content">
+<p class="admonition-title"><a href="#ex-nonumber-title">Solution to This is a title</a></p><div class="solution-content section" id="proof-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>
 </div>

--- a/tests/test_solution/_solution_with_exercise_nonumber_title.html
+++ b/tests/test_solution/_solution_with_exercise_nonumber_title.html
@@ -1,5 +1,5 @@
 <div class="proof solution admonition" id="sol-nonumber-title">
-<p class="admonition-title"><span><a href="#ex-nonumber-title">Solution to This is a title</a></p> </span><div class="solution-content section" id="proof-content">
+<p class="admonition-title"><span><a href="#ex-nonumber-title">Solution to This is a title</a></span></p><div class="solution-content section" id="proof-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>
 </div>

--- a/tests/test_solution/_solution_with_exercise_nonumber_title_inlinemath.html
+++ b/tests/test_solution/_solution_with_exercise_nonumber_title_inlinemath.html
@@ -1,0 +1,5 @@
+<div class="proof solution admonition" id="sol-nonumber-title-math">
+<p class="admonition-title"><a href="#ex-nonumber-title-math">Solution to This is a title <span class="math notranslate nohighlight">\(\mathbb{R}\)</span></a></p><div class="solution-content section" id="proof-content">
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</div>
+</div>

--- a/tests/test_solution/_solution_with_exercise_nonumber_title_inlinemath2.html
+++ b/tests/test_solution/_solution_with_exercise_nonumber_title_inlinemath2.html
@@ -1,0 +1,5 @@
+<div class="proof solution admonition" id="sol-nonumber-title-math2">
+<p class="admonition-title"><a href="#ex-nonumber-title-math2">Solution to This is a title <span class="math notranslate nohighlight">\(P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\)</span></a></p><div class="solution-content section" id="proof-content">
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</div>
+</div>

--- a/tests/test_solution/_solution_with_exercise_number.html
+++ b/tests/test_solution/_solution_with_exercise_number.html
@@ -1,0 +1,10 @@
+<div class="proof solution admonition" id="sol-number">
+<p class="admonition-title"><span><a href="#ex-number">Solution to Exercise 5</a></p> </span><div class="solution-content section" id="proof-content">
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+<div class="math notranslate nohighlight">
+\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
+<p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<div class="math notranslate nohighlight" id="equation-ex-math">
+<span class="eqno">(3)<a class="headerlink" href="#equation-ex-math" title="Permalink to this equation">¶</a></span>\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
+</div>
+</div>

--- a/tests/test_solution/_solution_with_exercise_number.html
+++ b/tests/test_solution/_solution_with_exercise_number.html
@@ -1,5 +1,5 @@
 <div class="proof solution admonition" id="sol-number">
-<p class="admonition-title"><span><a href="#ex-number">Solution to Exercise 5</a></p> </span><div class="solution-content section" id="proof-content">
+<p class="admonition-title"><span><a href="#ex-number">Solution to Exercise 5</a></span></p><div class="solution-content section" id="proof-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 <div class="math notranslate nohighlight">
 \[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>

--- a/tests/test_solution/_solution_with_label_and_class.html
+++ b/tests/test_solution/_solution_with_label_and_class.html
@@ -1,0 +1,5 @@
+<div class="proof solution test-solution admonition" id="solution-label">
+<p class="admonition-title"><span><a href="#ex-number">Solution to Exercise </a></p> </span><div class="solution-content section" id="proof-content">
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</div>
+</div>

--- a/tests/test_solution/_solution_with_label_and_class.html
+++ b/tests/test_solution/_solution_with_label_and_class.html
@@ -1,5 +1,5 @@
 <div class="proof solution test-solution admonition" id="solution-label">
-<p class="admonition-title"><span><a href="#ex-number">Solution to Exercise </a></p> </span><div class="solution-content section" id="proof-content">
+<p class="admonition-title"><span><a href="#ex-number">Solution to Exercise </a></span></p><div class="solution-content section" id="proof-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>
 </div>


### PR DESCRIPTION
 *** **IN PROGRESS** ***

This PR introduces a new `solution` directive. The solution directive will reference an `exercise` directive. The syntax is as follows:

````
```{proof:exercise} Exercise 1
:label: ex1-label

This is an exercise directive.
```

```{proof:solution} ex1-label
This is the solution associated with the above exercise.
```
````
For more information on how this directive behaves, either check the deployed Netlify link below or read through #18.

Additional `algorithm` and `proof` tests have been introduced to take into account any new changes introduced with the new directive. These tests include:
- _algo_title_with_inline_math
- _algo_with_labeled_math
- _algo_unlabeled_math
- _proof_inline_math_argument

**Solution** tests include:
- [x] `solution` with an enumerable `exercise`
- [x] `solution` with an unenumerable + simple title `exercise`
- [x] `solution` with an unenumerable+ inline-math title `exercise`
- [x] `solution` with an unenumerable + not titled `exercise`
- [x] `solution` missing its argument
- [x] `solution` where the argument is incorrect `exercise` label
- [x] `solution` using `label` and `class` options
- [x] `solution` referencing an enumerable `exercise`
- [x] `solution` referencing an unenumerable + simple title `exercise`
- [x] `solution` referencing an unenumerable + inline-math title `exercise`
- [x] `solution` referencing an unenumerable + not titled `exercise`
- [x] `solution` referencing incorrect `solution` label
- [x] `solution` with duplicate label