### PR TITLE
🔧 MAINTAIN: Update links to reflect migration to EBP

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ We welcome all contributions! See the [EBP Contributing Guide](https://executabl
 [rtd-link]: https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest
 [github-ci]: https://github.com/executablebooks/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master
 [github-link]: https://github.com/executablebooks/sphinxcontrib-prettyproof
-[codecov-badge]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof/branch/master/graph/badge.svg
-[codecov-link]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof
+[codecov-badge]: https://codecov.io/gh/executablebooks/sphinxcontrib-prettyproof/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/executablebooks/sphinxcontrib-prettyproof

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We welcome all contributions! See the [EBP Contributing Guide](https://executabl
 
 [rtd-badge]: https://readthedocs.org/projects/sphinxcontrib-prettyproof/badge/?version=latest
 [rtd-link]: https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest
-[github-ci]: https://github.com/najuzilu/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master
-[github-link]: https://github.com/najuzilu/sphinxcontrib-prettyproof
+[github-ci]: https://github.com/executablebooks/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master
+[github-link]: https://github.com/executablebooks/sphinxcontrib-prettyproof
 [codecov-badge]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ html_theme = "sphinx_book_theme"
 
 html_theme_options = {
     "path_to_docs": "docs",
-    "repository_url": "https://github.com/najuzilu/sphinxcontrib-prettyproof",
+    "repository_url": "https://github.com/executablebooks/sphinxcontrib-prettyproof",
     "use_edit_page_button": True,
     "use_issues_button": True,
     "use_repository_button": True,

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -69,5 +69,5 @@ you may then build using `make html` and the extension will be used by your `Sph
 [rtd-link]: https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest
 [github-ci]: https://github.com/executablebooks/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master
 [github-link]: https://github.com/executablebooks/sphinxcontrib-prettyproof
-[codecov-badge]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof/branch/master/graph/badge.svg
-[codecov-link]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof
+[codecov-badge]: https://codecov.io/gh/executablebooks/sphinxcontrib-prettyproof/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/executablebooks/sphinxcontrib-prettyproof

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -67,7 +67,7 @@ you may then build using `make html` and the extension will be used by your `Sph
 
 [rtd-badge]: https://readthedocs.org/projects/sphinxcontrib-prettyproof/badge/?version=latest
 [rtd-link]: https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest
-[github-ci]: https://github.com/najuzilu/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master
-[github-link]: https://github.com/najuzilu/sphinxcontrib-prettyproof
+[github-ci]: https://github.com/executablebooks/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master
+[github-link]: https://github.com/executablebooks/sphinxcontrib-prettyproof
 [codecov-badge]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -10,7 +10,7 @@ You can also install directly from the repository to get the latest `development
 You can clone the repository:
 
 ```bash
-git clone https://github.com/najuzilu/sphinxcontrib-prettyproof
+git clone https://github.com/executablebooks/sphinxcontrib-prettyproof
 ```
 
 then run:
@@ -24,7 +24,7 @@ python setup.py install
 To install `sphinxcontrib-prettyproof` for package development:
 
 ```bash
-git clone https://github.com/najuzilu/sphinxcontrib-prettyproof
+git clone https://github.com/executablebooks/sphinxcontrib-prettyproof
 cd sphinxcontrib-prettyproof
 git checkout master
 pip install -e .[all]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ This project is maintained and supported by [najuzilu](https://github.com/najuzi
 
 SHORT_DESCRIPTION = "A Sphinx extension for producing proofs, theorems, axioms, etc."
 
-URL = f"https://github.com/executablebooks/sphinxcontrib-prettyproof/archive/{VERSION}.tar.gz"
+BASE_URL = "https://github.com/executablebooks/sphinxcontrib-prettyproof"
+URL = f"{BASE_URL}/archive/{VERSION}.tar.gz"
 
 # Define all extras
 extras = {
@@ -44,11 +45,11 @@ setup(
     python_requires=">=3.6",
     author="QuantEcon",
     author_email="admin@quantecon.org",
-    url="https://github.com/executablebooks/sphinxcontrib-prettyproof",
+    url=BASE_URL,
     download_url=URL,
     project_urls={
-        "Source": "https://github.com/executablebooks/sphinxcontrib-prettyproof",
-        "Tracker": "https://github.com/executablebooks/sphinxcontrib-prettyproof/issues",
+        "Source": BASE_URL,
+        "Tracker": f"{BASE_URL}/issues",
     },
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ This project is maintained and supported by [najuzilu](https://github.com/najuzi
 
 SHORT_DESCRIPTION = "A Sphinx extension for producing proofs, theorems, axioms, etc."
 
-URL = f"https://github.com/najuzilu/sphinxcontrib-prettyproof/archive/{VERSION}.tar.gz"
+URL = f"https://github.com/executablebooks/sphinxcontrib-prettyproof/archive/{VERSION}.tar.gz"
 
 # Define all extras
 extras = {
@@ -44,11 +44,11 @@ setup(
     python_requires=">=3.6",
     author="QuantEcon",
     author_email="admin@quantecon.org",
-    url="https://github.com/najuzilu/sphinxcontrib-prettyproof",
+    url="https://github.com/executablebooks/sphinxcontrib-prettyproof",
     download_url=URL,
     project_urls={
-        "Source": "https://github.com/najuzilu/sphinxcontrib-prettyproof",
-        "Tracker": "https://github.com/najuzilu/sphinxcontrib-prettyproof/issues",
+        "Source": "https://github.com/executablebooks/sphinxcontrib-prettyproof",
+        "Tracker": "https://github.com/executablebooks/sphinxcontrib-prettyproof/issues",
     },
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
This PR updates most links to reflect the new destination under the Executable Books Project.

@choldgraf @chrisjsewell I would appreciate if you could advise on the best way to update Netlify and Codecov so I can update both accordingly.