### PR TITLE
🗑️ DEPRECATE: Remove exercise directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This package contains a [Sphinx](http://www.sphinx-doc.org/en/master/) extension
 for producing proof, theorem, axiom, lemma, definition, criterion, remark, conjecture,
-corollary, algorithm, exercise, example, property, observation and proposition directives.
+corollary, algorithm, example, property, observation and proposition directives.
 
 
 ## Get started

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,7 +5,6 @@
 
 install
 syntax
-contribute
 testing
 zreferences
 ```
@@ -18,7 +17,7 @@ zreferences
 
 This package contains a [Sphinx](http://www.sphinx-doc.org/en/master/) extension
 for producing proof, theorem, axiom, lemma, definition, criterion, remark, conjecture,
-corollary, algorithm, exercise, example, property, observation and proposition directives.
+corollary, algorithm, example, property, observation and proposition directives.
 
 
 ```{warning}

--- a/docs/source/syntax.md
+++ b/docs/source/syntax.md
@@ -514,58 +514,6 @@ _Source:_ [Wikipedia](https://en.wikipedia.org/wiki/Ford%E2%80%93Fulkerson_algor
 
 You can refer to a algorithms using the `{proof:ref}` role like: ```{proof:ref}`my-algorithm` ```, which will replace the reference with the algorithm number like so: {proof:ref}`my-algorithm`. When an explicit text is provided, this caption will serve as the title of the reference.
 
-## Exercises
-
-An exercise directive can be included using the `proof:exercise` pattern. The directive is enumerated by default and can take in an optional title argument. The following options are also supported:
-
-* `label` : text
-
-	A unique identifier for your exercise that you can use to reference it with `{proof:ref}`. Cannot contain spaces or special characters.
-* `class` : text
-
-	Value of the exercise’s class attribute which can be used to add custom CSS or JavaScript.
-* `nonumber` : flag (empty)
-
-	Turns off exercise auto numbering.
-
-**Example**
-
-```{proof:exercise}
-:label: my-exercise
-
-Recall that $n!$ is read as "$n$ factorial" and defined as
-$n! = n \times (n - 1) \times \cdots \times 2 \times 1$.
-
-There are functions to compute this in various modules, but let's
-write our own version as an exercise.
-
-In particular, write a function `factorial` such that `factorial(n)` returns $n!$
-for any positive integer $n$.
-```
-
-**MyST Syntax**
-
-``````md
-```{proof:exercise}
-:label: my-exercise
-
-Recall that $n!$ is read as "$n$ factorial" and defined as
-$n! = n \times (n - 1) \times \cdots \times 2 \times 1$.
-
-There are functions to compute this in various modules, but let's
-write our own version as an exercise.
-
-In particular, write a function `factorial` such that `factorial(n)` returns $n!$
-for any positive integer $n$.
-```
-``````
-
-_Source:_ [QuantEcon](https://python-programming.quantecon.org/functions.html#Exercise-1)
-
-### Referencing Exercises
-
-You can refer to an exercise using the `{proof:ref}` role like: ```{proof:ref}`my-exercise` ```, which will replace the reference with the exercise number like so: {proof:ref}`my-exercise`. When an explicit text is provided, this caption will serve as the title of the reference.
-
 
 ## Examples
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@ VERSION = "v0.0.2a"
 LONG_DESCRIPTION = """
 This package contains a [Sphinx](http://www.sphinx-doc.org/en/master/) extension
 for producing proof, theorem, axiom, lemma, definition, criterion, remark, conjecture,
-corollary, algorithm, exercise, example, property, observation and proposition
-directives.
+corollary, algorithm, example, property, observation and proposition directives.
 
 This project is maintained and supported by [najuzilu](https://github.com/najuzilu).
 """

--- a/sphinxcontrib/_static/proof.css
+++ b/sphinxcontrib/_static/proof.css
@@ -81,18 +81,6 @@ div.criterion p.admonition-title {
 }
 
 /*********************************************
-* Exercise *
-*********************************************/
-div.exercise {
-	border-left: .2rem solid var(--note-border-color);
-	background-color: var(--note-title-color);
-}
-
-div.exercise p.admonition-title {
-	background-color: var(--note-title-color);
-}
-
-/*********************************************
 * Lemma *
 *********************************************/
 div.lemma {

--- a/sphinxcontrib/prettyproof/proof_type.py
+++ b/sphinxcontrib/prettyproof/proof_type.py
@@ -65,12 +65,6 @@ class AxiomDirective(ElementDirective):
     name = "axiom"
 
 
-class ExerciseDirective(ElementDirective):
-    """A custom exercise directive."""
-
-    name = "exercise"
-
-
 class ExampleDirective(ElementDirective):
     """A custom example directive."""
 
@@ -105,7 +99,6 @@ PROOF_TYPES = {
     "corollary": CorollaryDirective,
     "algorithm": AlgorithmDirective,
     "criterion": CriterionDirective,
-    "exercise": ExerciseDirective,
     "example": ExampleDirective,
     "property": PropertyDirective,
     "observation": ObservationDirective,


### PR DESCRIPTION
Per the discussion in #32, this PR removes the `exercise` directive from the current extension. This directive is being moved to its own extension currently located [here](https://github.com/najuzilu/sphinx-exercise) but will the hope that it will be migrated to EBP very soon.