### PR TITLE
🐛 FIX: RTD fail to install local extension

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,4 +12,7 @@ sphinx:
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - rtd


### PR DESCRIPTION
This PR updates `.readthedocs.yml` to install dependencies using `pip install .[rtd]`.